### PR TITLE
Update thresholdReported on reset() and reveal()

### DIFF
--- a/example/lib/basic.dart
+++ b/example/lib/basic.dart
@@ -9,6 +9,7 @@ class BasicScreen extends StatefulWidget {
 
 class _BasicScreenState extends State<BasicScreen> {
   double progress = 0;
+  bool thresholdReached = false;
   final key = GlobalKey<ScratcherState>();
 
   @override
@@ -20,6 +21,7 @@ class _BasicScreenState extends State<BasicScreen> {
           brushSize: 30,
           threshold: 30,
           color: Colors.red,
+          onThreshold: () => setState(() => thresholdReached = true),
           onChange: (value) {
             setState(() {
               progress = value;
@@ -52,6 +54,7 @@ class _BasicScreenState extends State<BasicScreen> {
               key.currentState.reset(
                 duration: const Duration(milliseconds: 2000),
               );
+              setState(() => thresholdReached = false);
             },
           ),
         ),
@@ -72,6 +75,13 @@ class _BasicScreenState extends State<BasicScreen> {
           right: 10,
           child: Text(
             '${progress.round().toString()}%',
+          ),
+        ),
+        Positioned(
+          bottom: 30,
+          right: 10,
+          child: Text(
+            'Threshold reached: $thresholdReached',
           ),
         )
       ],

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -305,6 +305,10 @@ class ScratcherState extends State<Scratcher> {
       transitionDuration = duration;
       isFinished = true;
       canScratch = false;
+      if (!thresholdReported && widget.threshold != null) {
+        thresholdReported = true;
+        widget.onThreshold?.call();
+      }
     });
 
     widget.onChange?.call(100);

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -277,6 +277,7 @@ class ScratcherState extends State<Scratcher> {
       transitionDuration = duration;
       isFinished = false;
       canScratch = duration == null ? true : false;
+      thresholdReported = false;
 
       _lastPosition = null;
       points = [];


### PR DESCRIPTION
Hello vintage!
The property _thresholdReported_ wasn't updated when calling the _reset()_ method or the _reveal()_ method, so I updated the property in both methods.
I also updated the basic example: now it shows the current state of the thresholdReported property.