### PR TITLE
Migrate to null safety. 

### DIFF
--- a/lib/painter.dart
+++ b/lib/painter.dart
@@ -14,19 +14,19 @@ class ScratchPainter extends CustomPainter {
   });
 
   /// List of revealed points from scratcher
-  final List<ScratchPoint> points;
+  final List<ScratchPoint?>? points;
 
   /// Background color of the scratch area
-  final Color color;
+  final Color? color;
 
   /// Path to local image which can be used as scratch area
-  final ui.Image image;
+  final ui.Image? image;
 
   /// Determine how the image should fit the scratch area
-  final BoxFit imageFit;
+  final BoxFit? imageFit;
 
   /// Callback called each time the painter is redraw
-  final void Function(Size) onDraw;
+  final void Function(Size)? onDraw;
 
   Paint _getMainPaint(double strokeWidth) {
     final paint = Paint()
@@ -41,27 +41,27 @@ class ScratchPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    onDraw(size);
+    onDraw!(size);
 
     canvas.saveLayer(null, Paint());
 
     final areaRect = Rect.fromLTRB(0, 0, size.width, size.height);
-    canvas.drawRect(areaRect, Paint()..color = color);
+    canvas.drawRect(areaRect, Paint()..color = color!);
     if (image != null) {
-      final imageSize = Size(image.width.toDouble(), image.height.toDouble());
-      final sizes = applyBoxFit(imageFit, imageSize, size);
+      final imageSize = Size(image!.width.toDouble(), image!.height.toDouble());
+      final sizes = applyBoxFit(imageFit!, imageSize, size);
       final inputSubrect =
           Alignment.center.inscribe(sizes.source, Offset.zero & imageSize);
       final outputSubrect =
           Alignment.center.inscribe(sizes.destination, areaRect);
-      canvas.drawImageRect(image, inputSubrect, outputSubrect, Paint());
+      canvas.drawImageRect(image!, inputSubrect, outputSubrect, Paint());
     }
 
     var path = Path();
     var isStarted = false;
-    ScratchPoint previousPoint;
+    ScratchPoint? previousPoint;
 
-    for (final point in points) {
+    for (final point in points!) {
       if (point == null) {
         if (previousPoint != null) {
           canvas.drawPath(path, _getMainPaint(previousPoint.size));
@@ -73,9 +73,9 @@ class ScratchPainter extends CustomPainter {
         final position = point.position;
         if (!isStarted) {
           isStarted = true;
-          path.moveTo(position.dx, position.dy);
+          path.moveTo(position!.dx, position.dy);
         } else {
-          path.lineTo(position.dx, position.dy);
+          path.lineTo(position!.dx, position.dy);
         }
       }
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -3,6 +3,6 @@ import 'package:flutter/material.dart';
 class ScratchPoint {
   ScratchPoint(this.position, this.size);
 
-  final Offset position;
+  final Offset? position;
   final double size;
 }

--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -38,8 +38,8 @@ double _getAccuracyValue(ScratchAccuracy accuracy) {
 /// Scratcher widget which covers given child with scratchable overlay.
 class Scratcher extends StatefulWidget {
   Scratcher({
-    Key key,
-    @required this.child,
+    Key? key,
+    required this.child,
     this.enabled = true,
     this.threshold,
     this.brushSize = 25,
@@ -60,7 +60,7 @@ class Scratcher extends StatefulWidget {
   final bool enabled;
 
   /// Percentage level of scratch area which should be revealed to complete.
-  final double threshold;
+  final double? threshold;
 
   /// Size of the brush. The bigger it is the faster user can scratch the card.
   final double brushSize;
@@ -73,33 +73,33 @@ class Scratcher extends StatefulWidget {
   final Color color;
 
   /// Image widget used to cover the child widget.
-  final Image image;
+  final Image? image;
 
   /// Callback called when new part of area is revealed (min 0.1% difference, or progress == 100).
-  final Function(double value) onChange;
+  final Function(double value)? onChange;
 
   /// Callback called when threshold is reached.
-  final VoidCallback onThreshold;
+  final VoidCallback? onThreshold;
 
   /// Callback called when scratching starts
-  final VoidCallback onScratchStart;
+  final VoidCallback? onScratchStart;
 
   /// Callback called during scratching
-  final VoidCallback onScratchUpdate;
+  final VoidCallback? onScratchUpdate;
 
   /// Callback called when scratching ends
-  final VoidCallback onScratchEnd;
+  final VoidCallback? onScratchEnd;
 
   @override
   ScratcherState createState() => ScratcherState();
 }
 
 class ScratcherState extends State<Scratcher> {
-  Future<ui.Image> _imageLoader;
-  Offset _lastPosition;
+  Future<ui.Image>? _imageLoader;
+  Offset? _lastPosition;
 
-  List<ScratchPoint> points = [];
-  Set<Offset> checkpoints;
+  List<ScratchPoint?> points = [];
+  late Set<Offset> checkpoints;
   Set<Offset> checked = {};
   int totalCheckpoints = 0;
   double progress = 0;
@@ -107,10 +107,10 @@ class ScratcherState extends State<Scratcher> {
   bool thresholdReported = false;
   bool isFinished = false;
   bool canScratch = true;
-  Duration transitionDuration;
+  Duration? transitionDuration;
 
-  RenderBox get _renderObject {
-    return context.findRenderObject() as RenderBox;
+  RenderBox? get _renderObject {
+    return context.findRenderObject() as RenderBox?;
   }
 
   @override
@@ -119,7 +119,7 @@ class ScratcherState extends State<Scratcher> {
       final completer = Completer<ui.Image>()..complete();
       _imageLoader = completer.future;
     } else {
-      _imageLoader = _loadImage(widget.image);
+      _imageLoader = _loadImage(widget.image!);
     }
 
     super.initState();
@@ -136,7 +136,7 @@ class ScratcherState extends State<Scratcher> {
               image: snapshot.data,
               imageFit: widget.image == null
                   ? null
-                  : widget.image.fit ?? BoxFit.cover,
+                  : widget.image!.fit ?? BoxFit.cover,
               points: points,
               color: widget.color,
               onDraw: (size) {
@@ -193,9 +193,9 @@ class ScratcherState extends State<Scratcher> {
 
     imageProvider.load(key, (
       Uint8List bytes, {
-      int cacheWidth,
-      int cacheHeight,
-      bool allowUpscaling,
+      int? cacheWidth,
+      int? cacheHeight,
+      bool? allowUpscaling,
     }) async {
       return ui.instantiateImageCodec(bytes);
     }).addListener(ImageStreamListener((ImageInfo image, _) {
@@ -221,7 +221,7 @@ class ScratcherState extends State<Scratcher> {
     }
     _lastPosition = position;
 
-    var point = position;
+    ui.Offset? point = position;
 
     // Ignore when starting point of new line has been already scratched
     if (points.isNotEmpty && points.contains(point)) {
@@ -258,7 +258,7 @@ class ScratcherState extends State<Scratcher> {
 
       if (!thresholdReported &&
           widget.threshold != null &&
-          progress >= widget.threshold) {
+          progress >= widget.threshold!) {
         thresholdReported = true;
         widget.onThreshold?.call();
       }
@@ -296,7 +296,7 @@ class ScratcherState extends State<Scratcher> {
   }
 
   /// Resets the scratcher state to the initial values.
-  void reset({Duration duration}) {
+  void reset({Duration? duration}) {
     setState(() {
       transitionDuration = duration;
       isFinished = false;
@@ -319,12 +319,12 @@ class ScratcherState extends State<Scratcher> {
       });
     }
 
-    _setCheckpoints(_renderObject.size);
+    _setCheckpoints(_renderObject!.size);
     widget.onChange?.call(0);
   }
 
   /// Reveals the whole scratcher, so than only original child is displayed.
-  void reveal({Duration duration}) {
+  void reveal({Duration? duration}) {
     setState(() {
       transitionDuration = duration;
       isFinished = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/vintage/scratcher
 version: 1.6.0
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=2.0.0"
 
 dependencies:


### PR DESCRIPTION
This cool library hasn't been migrated to null safety, so I just ran `dart migrate` on it.

I don't know much about how the library works, but the changes don't seem too bad. If there is something else that should be fixed or changes I can try to make the changes. 

Related to issue #26 
