### PR TITLE
Improve performance

### DIFF
--- a/lib/widgets.dart
+++ b/lib/widgets.dart
@@ -249,15 +249,11 @@ class ScratcherState extends State<Scratcher> {
     if (point != null && !checked.contains(point)) {
       checked.add(point);
 
-      final reached = <Offset>{};
-      for (final checkpoint in checkpoints) {
-        final radius = widget.brushSize / 2;
-        if (_inCircle(checkpoint, point, radius)) {
-          reached.add(checkpoint);
-        }
-      }
+      final radius = widget.brushSize / 2;
+      checkpoints.removeWhere(
+        (checkpoint) => _inCircle(checkpoint, point!, radius),
+      );
 
-      checkpoints = checkpoints.difference(reached);
       progress =
           ((totalCheckpoints - checkpoints.length) / totalCheckpoints) * 100;
       if (progress - progressReported >= _progressReportStep ||


### PR DESCRIPTION
`Set.difference()` is refactored as it is extremely slow

Tested on PC browser, work well with ~~both _html_ and~~ _canvaskit_ renderers (ahh Flutter will default to canvaskit if it's on PC, if we specificly call `--web-renderer html` it'll not work, just like on mobile browser)

Have not tested on any ~~mobile browser~~/physical mobile device

* **Mobile browser**: still freezes with html renderer ~~(maybe a Flutter web internal bug)~~. **edit: The entire `Paint()` module relies on Skia API, so it'll never work with html renderer...**
* **Real device**: v2 embedding needed