### PR TITLE
fixed scratches not being shown on ios

### DIFF
--- a/lib/painter.dart
+++ b/lib/painter.dart
@@ -31,9 +31,9 @@ class ScratchPainter extends CustomPainter {
   Paint _getMainPaint(double strokeWidth) {
     final paint = Paint()
       ..strokeCap = StrokeCap.round
-      ..color = Colors.transparent
+      ..color = Colors.white
       ..strokeWidth = strokeWidth
-      ..blendMode = BlendMode.src
+      ..blendMode = BlendMode.clear
       ..strokeJoin = StrokeJoin.round
       ..style = PaintingStyle.stroke;
 


### PR DESCRIPTION
This will fix the ios issue since flutter 3.13 where the scratches are not displayed correctly. (when scratching nothing is displayed as being scratched)